### PR TITLE
Remove deprecated version of dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ platforms/
 tmp/
 typings/
 .idea
+/.project

--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
   },
   "dependencies": {
     "nativescript-theme-core": "~1.0.2"
-  },
-  "devDependencies": {
-    "nativescript-dev-android-snapshot": "^0.*.*"
   }
 }


### PR DESCRIPTION
It can be added once new version is out and compatible with cloud
builds.