### PR TITLE
Change action bar layout to have action-bar-title

### DIFF
--- a/home/home-page.xml
+++ b/home/home-page.xml
@@ -3,7 +3,8 @@
     xmlns="http://www.nativescript.org/tns.xsd">
 
     <!--Add your page content here-->
-    <ActionBar title="Home" class="action-bar">
+    <ActionBar class="action-bar">
+        <Label class="action-bar-title" text="Home"></Label>
     </ActionBar>
 
     <GridLayout>


### PR DESCRIPTION
Change action bar layout to use the same layout as the other templates. In this way the page title will be always center. Otherwise once will be center, another time - left