### PR TITLE
feat: add javascript intellisense support in vscode

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "allowSyntheticDefaultImports": false,
+    "baseUrl": "./",
+    "paths": {
+      "~/*": ["app/*"]
+    }
+  },
+  "exclude": ["node_modules", "platforms", "hooks"]
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,11 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es2017",
-    "allowSyntheticDefaultImports": false,
     "baseUrl": "./",
     "paths": {
+      "*": ["./node_modules/tns-core-modules/*", "./node_modules/*"],
       "~/*": ["app/*"]
     }
   },
-  "exclude": ["node_modules", "platforms", "hooks"]
+  "include": ["app/**/*"]
 }


### PR DESCRIPTION
If this PR is merged,
when users import with paths starting from ~ they will get intellisense.